### PR TITLE
update endpoint url

### DIFF
--- a/config/chebi-inchi_key/config.yaml
+++ b/config/chebi-inchi_key/config.yaml
@@ -4,4 +4,4 @@ link:
   file: sample.tsv
 update:
   frequency: threeTimesAYear
-  method: sparql_csv2tsv.sh query.rq  https://integbio.jp/togosite/sparql
+  method: sparql_csv2tsv.sh query.rq https://togodx.dbcls.jp/human/sparql

--- a/config/chebi-inchi_key/query.rq
+++ b/config/chebi-inchi_key/query.rq
@@ -1,4 +1,4 @@
-# Endpoint: https://integbio.jp/togosite/sparql
+# Endpoint: https://togodx.dbcls.jp/human/sparql
 # Graph: http://rdf.integbio.jp/dataset/togosite/chebi
 
 PREFIX obo: <http://purl.obolibrary.org/obo/>

--- a/config/medgen-hp/config.yaml
+++ b/config/medgen-hp/config.yaml
@@ -4,4 +4,4 @@ link:
   file: sample.tsv
 update:
   frequency: Daily
-  method: sparql_csv2tsv.sh query.rq https://integbio.jp/togosite/sparql
+  method: sparql_csv2tsv.sh query.rq https://togodx.dbcls.jp/human/sparql

--- a/config/medgen-mesh/config.yaml
+++ b/config/medgen-mesh/config.yaml
@@ -4,4 +4,4 @@ link:
   file: sample.tsv
 update:
   frequency: Daily
-  method: sparql_csv2tsv.sh query.rq https://integbio.jp/togosite/sparql
+  method: sparql_csv2tsv.sh query.rq https://togodx.dbcls.jp/human/sparql

--- a/config/medgen-mondo/config.yaml
+++ b/config/medgen-mondo/config.yaml
@@ -4,4 +4,4 @@ link:
   file: sample.tsv
 update:
   frequency: Daily
-  method: sparql_csv2tsv.sh query.rq https://integbio.jp/togosite/sparql
+  method: sparql_csv2tsv.sh query.rq https://togodx.dbcls.jp/human/sparql

--- a/config/medgen-ncbigene/config.yaml
+++ b/config/medgen-ncbigene/config.yaml
@@ -4,4 +4,4 @@ link:
   file: sample.tsv
 update:
   frequency:
-  method: sparql_csv2tsv.sh query.rq https://integbio.jp/togosite/sparql
+  method: sparql_csv2tsv.sh query.rq https://togodx.dbcls.jp/human/sparql

--- a/config/medgen-omim_phenotype/config.yaml
+++ b/config/medgen-omim_phenotype/config.yaml
@@ -4,4 +4,4 @@ link:
   file: sample.tsv
 update:
   frequency: Daily
-  method: sparql_csv2tsv.sh query.rq https://integbio.jp/togosite/sparql
+  method: sparql_csv2tsv.sh query.rq https://togodx.dbcls.jp/human/sparql

--- a/config/medgen-orphanet/config.yaml
+++ b/config/medgen-orphanet/config.yaml
@@ -4,4 +4,4 @@ link:
   file: sample.tsv
 update:
   frequency: Daily
-  method: sparql_csv2tsv.sh query.rq https://integbio.jp/togosite/sparql
+  method: sparql_csv2tsv.sh query.rq https://togodx.dbcls.jp/human/sparql

--- a/config/nando-mondo/config.yaml
+++ b/config/nando-mondo/config.yaml
@@ -4,4 +4,4 @@ link:
   file: sample.tsv
 update:
   frequency: Irregular
-  method: sparql_csv2tsv.sh query.rq https://integbio.jp/togosite/sparql
+  method: sparql_csv2tsv.sh query.rq https://togodx.dbcls.jp/human/sparql

--- a/config/nando-mondo/query.rq
+++ b/config/nando-mondo/query.rq
@@ -1,4 +1,4 @@
-# Endpoint: https://integbio.jp/togosite/sparql
+# Endpoint: https://togodx.dbcls.jp/human/sparql
 PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 


### PR DESCRIPTION
TogoDX の SPARQL エンドポイント https://integbio.jp/togosite/sparql が https://togodx.dbcls.jp/human/sparql に移設されたのに対応した。
該当するデータセットは MedGen, ChEBI, NANDO の 3 つ。
TogoID の更新が TogoDX のエンドポイントを見る必然性はないので、RDF Portal を見るようにしてもよいが、RDF Portal のほうは若干データが古い。当面は TogoDX エンドポイントを使用することにする。