### PR TITLE
use timestamp check

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -297,9 +297,8 @@ module TogoID
     def update_input_file?(file, url)
       if File.exists?(file)
         # Both checks should be made as the local file can be newer than remote when the previous download fails
-        check_remote_file_time(file, url)
         # and the local file can be smaller or size 0 even when it exists
-        check_remote_file_size(file, url)
+        check_remote_file_time(file, url) || check_remote_file_size(file, url)
       else
         true
       end


### PR DESCRIPTION
Rakefile 内でファイルのダウンロードをする際、ダウンロード済みのファイルとリモートのファイルのタイムスタンプの比較を `check_remote_file_time` で行っているのですが、これの返り値が `update_input_file?` の返り値に影響しておらず、更新の判断に使われていませんでした。
このため、リリースのバージョンの数値だけを記述したファイル(https://ftp.ncbi.nih.gov/refseq/release/RELEASE_NUMBER )を使って更新の判断をしようとしている RefSeq は、一度も更新されたことがないようです(最新版は 218, ep11 の input/refseq ディレクトリにあるのは 207)。つらい。

修正しましたのでご確認ください。