### PR TITLE
Update refseq method

### DIFF
--- a/config/refseq_rna-dbsnp/config.yaml
+++ b/config/refseq_rna-dbsnp/config.yaml
@@ -4,5 +4,4 @@ link:
   file: sample.tsv
 update:
   frequency: Bimonthly
-  method: gzip -dc $TOGOID_ROOT/input/refseq/complete.*.rna.gbff.gz | parse_refseq_rna_gbff.pl
-    --dbsnp | awk -F "\t" '$1 != "" && $2 != ""' | awk '!a[$0]++'
+  method: awk -F "\t" '$1&&$10{split($10, b, ","); for(k in b){if(!a[$1, b[k]]++)print $1 "\t" b[k]}}' $TOGOID_ROOT/input/refseq/refseq_rna_summary.tsv

--- a/config/refseq_rna-hgnc/config.yaml
+++ b/config/refseq_rna-hgnc/config.yaml
@@ -4,5 +4,4 @@ link:
   file: sample.tsv
 update:
   frequency: Bimonthly
-  method: gzip -dc $TOGOID_ROOT/input/refseq/complete.*.rna.gbff.gz | parse_refseq_rna_gbff.pl
-    --hgnc |  sed 's/HGNC://' | awk -F "\t" '$1 != "" && $2 != ""' | awk '!a[$0]++'
+  method: awk -F "\t" '$1&&$6&&!a[$1, $6]++{print $1 "\t" gensub("HGNC:", "", "g", $6)}' $TOGOID_ROOT/input/refseq/refseq_rna_summary.tsv

--- a/config/refseq_rna-ncbigene/config.yaml
+++ b/config/refseq_rna-ncbigene/config.yaml
@@ -4,5 +4,4 @@ link:
   file: sample.tsv
 update:
   frequency: Bimonthly
-  method: gzip -dc $TOGOID_ROOT/input/refseq/complete.*.rna.gbff.gz | parse_refseq_rna_gbff.pl
-    --geneid | awk -F "\t" '$1 != "" && $2 != ""' | awk '!a[$0]++'
+  method: awk -F "\t" '$1&&$5&&!a[$1, $5]++{print $1 "\t" $5}' $TOGOID_ROOT/input/refseq/refseq_rna_summary.tsv

--- a/config/refseq_rna-omim_gene/config.yaml
+++ b/config/refseq_rna-omim_gene/config.yaml
@@ -4,5 +4,4 @@ link:
   file: sample.tsv
 update:
   frequency: Bimonthly
-  method: gzip -dc $TOGOID_ROOT/input/refseq/complete.*.rna.gbff.gz | parse_refseq_rna_gbff.pl
-    --mim | awk -F "\t" '$1 != "" && $2 != ""' | awk '!a[$0]++'
+  method: awk -F "\t" '$1&&$8{split($8, b, ","); for(k in b){if(!a[$1, b[k]]++)print $1 "\t" b[k]}}' $TOGOID_ROOT/input/refseq/refseq_rna_summary.tsv

--- a/config/refseq_rna-pubmed/config.yaml
+++ b/config/refseq_rna-pubmed/config.yaml
@@ -4,5 +4,4 @@ link:
   file: sample.tsv
 update:
   frequency: Bimonthly
-  method: gzip -dc $TOGOID_ROOT/input/refseq/complete.*.rna.gbff.gz | parse_refseq_rna_gbff.pl
-    --pmid | awk -F "\t" '$1 != "" && $2 != ""' | awk '!a[$0]++'
+  method: awk -F "\t" '$1&&$9{split($9, b, ","); for(k in b){if(!a[$1, b[k]]++)print $1 "\t" b[k]}}' $TOGOID_ROOT/input/refseq/refseq_rna_summary.tsv

--- a/config/refseq_rna-refseq_protein/config.yaml
+++ b/config/refseq_rna-refseq_protein/config.yaml
@@ -4,5 +4,4 @@ link:
   file: sample.tsv
 update:
   frequency: Bimonthly
-  method: gzip -dc $TOGOID_ROOT/input/refseq/complete.*.rna.gbff.gz | parse_refseq_rna_gbff.pl
-    --protein | awk -F "\t" '$1 != "" && $2 != ""' | awk '!a[$0]++'
+  method: awk -F "\t" '$1&&$7&&!a[$1, $7]++{print $1 "\t" $7}' $TOGOID_ROOT/input/refseq/refseq_rna_summary.tsv

--- a/config/refseq_rna-taxonomy/config.yaml
+++ b/config/refseq_rna-taxonomy/config.yaml
@@ -4,5 +4,4 @@ link:
   reverse: TIO_000065
 update:
   frequency: Bimonthly
-  method: gzip -dc $TOGOID_ROOT/input/refseq/complete.*.rna.gbff.gz | parse_refseq_rna_gbff.pl
-    --taxon | awk -F "\t" '$1 != "" && $2 != ""' | awk '!a[$0]++'
+  method: awk -F "\t" '$1&&$3&&!a[$1, $3]++{print $1 "\t" $3}' $TOGOID_ROOT/input/refseq/refseq_rna_summary.tsv


### PR DESCRIPTION
refseq_rna-* の動作を効率化。

Rakefile は、gbff ファイルをダウンロード後に parse_refseq_rna_gbff.pl を `--summary` オプションで実行。
これにより input/refseq ディレクトリ内に、RefSeq RNA ID と対応する各種 ID のテーブルが refseq_rna_summary.tsv という単独のファイルとして出力される。
各ペアの config は、この tsv ファイルから当該列を抜き出す。

従来 parse_refseq_rna_gbff.pl の `--summary` オプションは、RefSeq RNA ID との対応が一対多である OMIM Gene, dbSNP, PubMed との対応は出力していなかった。
これを出力するように変更した。対応する ID が複数ある場合は、カンマ区切りの文字列として 1 列に納められ、1 行 1 ペアへの分解は各 config で行う。

また、gbff ファイルに付与されている番号 (例えば、complete.1000.rna.gbff.gz の 1000) は、RefSeq のリリースごとに必ず後ろに追加されることが保証されているというものではなく、
例えば古いリリースには complete.3000.rna.gbff.gz という名のファイルが存在するが、バージョン 218 現在では存在しない。
古いファイルを使わないよう、gbff ファイルのダウンロードを行う前に、input/refseq ディレクトリ内の gbff.gz ファイルを全て削除する動作を追加した。