### PR TITLE
use gene_info

### DIFF
--- a/config/ncbigene-mirbase/config.yaml
+++ b/config/ncbigene-mirbase/config.yaml
@@ -5,4 +5,4 @@ link:
 update:
   frequency: Weekly
   method: awk -F '\t' 'FNR!=1{split($6,a,"|");for(i in a){if(a[i]~/^miRBase:/)print
-    $2 "\t" gensub(/^.*:/,"","g",a[i])}}' $TOGOID_ROOT/input/ncbigene/Homo_sapiens.gene_info
+    $2 "\t" gensub(/^.*:/,"","g",a[i])}}' $TOGOID_ROOT/input/ncbigene/gene_info


### PR DESCRIPTION
ncbigene-mirbase が Homo_sapiens.gene_info から作られていたが、miRBase はヒト以外の生物種も 50 種ほどカバーしている。
つまり、ヒト以外もあるのに従来ヒトしか対応できていなかった。
Homo_sapiens.gene_info ではなく gene_info を使うように修正。

なお、同じく Homo_sapiens.gene_info を使っている ncbigene-hgnc と ncbigene-omim_gene はヒトしかないので問題なし。