### PR TITLE
fix task order of tsv file task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -383,9 +383,9 @@ include TogoID::Prepare
 # Dependency for TSV files (check dependency for preparation by target names)
 rule(/#{OUTPUT_TSV_DIR}\S+\.tsv/ => [
   OUTPUT_TSV_DIR,
-  method(:prepare_task),
-  method(:update_tsv)
+  method(:prepare_task)
 ]) do |t|
+  update_tsv(t.name)
   $stderr.puts "Rule for TSV (#{t.name})"
   $stderr.puts t.investigation if $verbose
 end


### PR DESCRIPTION
`$ rake output/tsv/source-target.tsv`
の形式で実行したときに、prepare よりも先に update が実行される不具合を修正。
cc. @ktym