### PR TITLE
release 2024-01-16 (2)

### DIFF
--- a/.github/workflows/build-container-and-push.yml
+++ b/.github/workflows/build-container-and-push.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - production
+    paths:
+      - 'docs/help.md'
+      - 'docs/help_ja.md'
 
 jobs:
   build_and_push:

--- a/.github/workflows/create-release-upload.yaml
+++ b/.github/workflows/create-release-upload.yaml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - production
+    paths:
+      - 'docs/help.md'
+      - 'docs/help_ja.md'
 jobs:
   release-production:
     runs-on: ubuntu-latest

--- a/bin/sparql_taxon.rb
+++ b/bin/sparql_taxon.rb
@@ -12,7 +12,7 @@ File.read(taxonomy_list).split("\n").each do |taxon|
   loop_count = 0
   while i % limit == 0
     if loop_count * limit != i
-      $stderr.puts "Error: Failed to retrieve taxon:#{taxon} in loop_count:#{loop_count}"
+      $stderr.puts "Warning: Failed to retrieve taxon:#{taxon} in loop_count:#{loop_count}"
       break
     end
     query = query_template.sub('{{taxon}}', taxon) + " OFFSET #{i} LIMIT #{limit}"

--- a/config/dataset.yaml
+++ b/config/dataset.yaml
@@ -6,6 +6,7 @@ affy_probeset:
   prefix: 'http://identifiers.org/affy.probeset/'
   examples:
     - ["1553582_a_at","211531_x_at","202573_at","201640_x_at","205117_at","201017_at","205099_s_at","200614_at","201895_at","202666_s_at"]
+  description: "The microarray probe set provided by Affymetrix."
 assembly_insdc:
   label: Assembly INSDC
   catalog: FIXME

--- a/config/togovar-clinvar/query.rq
+++ b/config/togovar-clinvar/query.rq
@@ -5,11 +5,11 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
 SELECT DISTINCT ?tgv_id ?variation_id
 WHERE {
-  GRAPH <http://togovar.biosciencedbc.jp/variant> {
+  GRAPH <http://togovar.org/variant> {
     ?variant dct:identifier ?tgv_id .
   }
 
-  GRAPH <http://togovar.biosciencedbc.jp/variant/annotation/clinvar> {
+  GRAPH <http://togovar.org/variant/annotation/clinvar> {
     ?variant dct:identifier ?variation_id .
   }
 } limit 2000000

--- a/docs/help.md
+++ b/docs/help.md
@@ -1,5 +1,5 @@
 # TogoID ver. 1.1
-Datasets last updated: 2024-01-09
+Datasets last updated: 2024-01-15
 
 ## About
 - [TogoID](https://togoid.dbcls.jp/) is an ID conversion service implementing unique features with an intuitive web interface and an API for programmatic access. TogoID supports datasets from various biological categories such as gene, protein, chemical compound, pathway, disease, etc. TogoID users can perform exploratory multistep conversions to find a path among IDs. To guide the interpretation of biological meanings in the conversions, we crafted an [ontology](https://togoid.dbcls.jp/ontology) that defines the semantics of the dataset relations.
@@ -22,7 +22,7 @@ Shuya Ikeda, Hiromasa Ono, Tazro Ohta, Hirokazu Chiba, Yuki Naito, Yuki Moriya, 
 
 - [API Documentation (Swagger)](https://togoid.dbcls.jp/apidoc/)
 
-## Statistics (as of 2024-01-09)
+## Statistics (as of 2024-01-15)
 - Number of target datasets 
     - 102 (from 72 databases)
 - For details on the target DBs and ID examples, please refer to the "DATASETS" tab. 

--- a/docs/help_ja.md
+++ b/docs/help_ja.md
@@ -1,5 +1,5 @@
 # TogoID ver. 1.1
-Datasets last updated: 2024-01-09
+Datasets last updated: 2024-01-15
 
 ## About
 - [TogoID](https://togoid.dbcls.jp/) は、直感的なインターフェースにより生命科学系データベース(DB)間のつながりを探索的に確認しながらID変換を行うことができるウェブアプリケーションです。同一の実体を指すID間の変換だけでなく、関連する別のカテゴリーのIDへの変換も可能です。また、直接リンクされていないDBのID間でも、他のDBを経由した変換を探索することができます。
@@ -28,7 +28,7 @@ Datasets last updated: 2024-01-09
 
 - [API Documentation (Swagger)](https://togoid.dbcls.jp/apidoc/)
 
-## 統計 (2024-01-09)
+## 統計 (2024-01-15)
 - 対象データセット数 
     - 102 (72のデータベースに由来)
 - 対象DBの詳細やID例については、"DATASETS" タブ からご覧いただけます。 

--- a/docs/news.md
+++ b/docs/news.md
@@ -1,0 +1,38 @@
+# 2024-01-10
+- Weekly update has been completed.
+
+# 2024-01-05
+- Weekly update has been completed.
+
+# 2023-12-26
+- Weekly update has been completed.
+
+# 2023-12-19
+- Weekly update has been completed.
+
+# 2023-12-12
+- Weekly update has been completed.
+
+# 2023-12-06
+- Weekly update has been completed.
+
+# 2023-11-29
+- Weekly update has been completed.
+
+# 2023-11-21
+- Weekly update has been completed.
+
+# 2023-11-15
+- Weekly update has been completed.
+
+# 2023-11-06
+- Weekly update has been completed.
+
+# 2023-10-31
+- Weekly update has been completed.
+
+# 2023-10-23
+- Weekly update has been completed.
+- 3 datasets have been added.
+  - MGI allele, MGI phenotype, Mammalian Phenotype ontology
+- The previous dataset name "MGI" has been renamed to "MGI Gene".


### PR DESCRIPTION
- The documents update which should have been done in #207 
- The workflows of `build-container-and-push` and `create-release-upload` are now run only when doc files are updated.