### PR TITLE
Fix biosample bioproject

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -556,7 +556,7 @@ namespace :prepare do
       if update_input_file?(input_file, input_url)
         download_file(INPUT_BIOSAMPLE_DIR, input_url)
         sh "gzip -dc #{input_file} > #{INPUT_BIOSAMPLE_DIR}/biosample_set.xml"
-        sh "python bin/biosample_xml2tsv.py biosample_set.xml > biosample_set.tsv"
+        sh "python bin/biosample_xml2tsv.py #{INPUT_BIOSAMPLE_DIR}/biosample_set.xml > #{INPUT_BIOSAMPLE_DIR}/biosample_set.tsv"
       end
     end
   end

--- a/bin/bioproject_xml2tsv.py
+++ b/bin/bioproject_xml2tsv.py
@@ -9,6 +9,7 @@ class XMLHandler(xml.sax.ContentHandler):
 
     def init_current_package(self):
         self.current_bpid = ""
+        self.current_id = ""  # internal ID
         self.current_title = ""
         self.current_xrefdb = ""
         self.current_content = ""
@@ -21,6 +22,7 @@ class XMLHandler(xml.sax.ContentHandler):
             self.init_current_package()
         if self.tag_stack == ["PackageSet", "Package", "Project", "Project", "ProjectID", "ArchiveID"]:
             self.current_bpid = attrs.getValue("accession")
+            self.current_id = attrs.getValue("id")
         elif self.tag_stack == ["PackageSet", "Package", "Project", "Project", "ProjectDescr", "Publication"]:
             self.current_pmids.append(attrs.getValue("id"))
         elif self.tag_stack == ["PackageSet", "Package", "Project", "Project", "ProjectDescr", "ExternalLink", "dbXREF"]:
@@ -35,6 +37,7 @@ class XMLHandler(xml.sax.ContentHandler):
     def endElement(self, tag):
         if self.tag_stack == ["PackageSet", "Package"]:
             print(self.current_bpid, "Title", self.current_title, sep="\t")
+            print(self.current_bpid, "ID", self.current_id, sep="\t")
             for pmid in self.current_pmids:
                 # ID might be PMC ID, DOI, etc. The type is not described in the xml.
                 if re.match(r"^[0-9]+$", pmid):

--- a/config/biosample-bioproject/config.yaml
+++ b/config/biosample-bioproject/config.yaml
@@ -4,4 +4,4 @@ link:
   reverse: TIO_000094
 update:
   frequency: Monthly
-  method: curl -sS https://ddbj.nig.ac.jp/public/rdf/dblink/biosample-bioproject/biosample2bioproject.tsv
+  method: awk -F "\t" 'FNR==NR&&$2=="ID"{a[$3]=$1}FNR!=NR&&$2=="BioProject ID"{print $1 "\t" $3 "\t" a[$3]}' $TOGOID_ROOT/input/bioproject/bioproject.tsv $TOGOID_ROOT/input/biosample/biosample_set.tsv


### PR DESCRIPTION
`biosample-bioproject` の取得方法を変更。
従来 DDBJ から取ってきていたものは、単に `bioproject-biosample` の逆だったようで、bioproject.xml から作られていた。
bioproject.xml に記述されている BioProject と BioSample のリンクは完全でない。理由は不明。
例えば [PRJNA388952](https://www.ncbi.nlm.nih.gov/bioproject/PRJNA388952) は 856 サンプル(例 [SAMN07187968](https://www.ncbi.nlm.nih.gov/biosample/SAMN07187968))を扱っているプロジェクトだが、このプロジェクトが扱っているサンプルの記述は bioproject.xml にはない。
TogoID 上では SRA experiment を経由することで繋げられるのだが、SRA と関係ないサンプルでも繋げられてほしい。
(実際に、SRA と関係なく且つ bioproject.xml の情報で直接つながらない BioProject - BioSample 関係があるかは確認していない。)

BioSample 側で提供している biosample_set.xml からペアを作るように変更した。
biosample_set.xml において、BioSample レコードから BioProject への参照の記法は統一されておらず、
```
<Link type="entrez" target="bioproject" label="PRJDB2653">248999</Link>
```
だったり
```
<Link type="entrez" target="bioproject">19655</Link>
```
だったりする。
content として書かれている数字は、BioProject の内部 ID のようなもの。bioproject.xml では、PRJ で始まる ID を accession と呼び、数字だけのほうを単に id と呼んでいる。
上記の例の通り、biosample_set.xml では、accession のほうは書かれていないことがある一方で、id の数字は常に書かれているようなのでこれを利用することに。
bioproject.xml から情報を抽出する `bioproject_xml2tsv.py` において、accession と id の対応関係も出力するように変更し、`biosample-bioproject` の config はこれを参照して bioproject の id を accession に変換している。
