### PR TITLE
abolish official symbol

### DIFF
--- a/config/dataset.yaml
+++ b/config/dataset.yaml
@@ -554,8 +554,6 @@ ncbigene:
         preferred: true
       - label: Synonym
         dictionary: togoid_ncbigene_synonym
-      - label: Official symbol
-        dictionary: togoid_ncbigene_official_symbol
 ncit_disease:
   label: NCIt disease
   catalog: FIXME


### PR DESCRIPTION
NCBI の提供している gene_info ファイルでは、NCBI がメインシンボルとして使っているものを `Symbol`, HGNC や MGI など生物種ごとのオーソリティにより定められたシンボルを `Symbol_from_nomenclature_authority` として分けている。
TogoID の LABEL2ID でも、これらを `NCBI Gene symbol` 及び `Official symbol` として分けていた。
ほとんどの場合両者は同じだが、ミトコンドリア遺伝子ではどの生物でも同じシンボルにしたいという NCBI Gene の方針があるため、異なることがある。
実際に両者が違うケースがどの程度あるのかは調べていなかった。
今回調べたところ、両者が違うのはゼブラフィッシュ、ショウジョウバエ、ヒト、マウス、ラットのミトコンドリア遺伝子のみで、合計 157 個しかなかった。
TogoID では、両者が分けてあることにより混乱を招くというデメリットのほうが大きい。
両者が異なる場合は Official symbol を synonym に入れておく、という対応にした。これで辞書は symbol と synonym の 2 つだけとなる。
https://pubdictionaries.org/dictionaries/togoid_ncbigene_symbol
https://pubdictionaries.org/dictionaries/togoid_ncbigene_synonym
