### PR TITLE
fix lipidmaps

### DIFF
--- a/bin/parse_lipidmaps_sdf.awk
+++ b/bin/parse_lipidmaps_sdf.awk
@@ -1,0 +1,24 @@
+BEGIN {
+    OFS = "\t"
+    RS = "\n\\$\\$\\$\\$\n"
+    FS = "\n\n"
+    attrs_str = "LM_ID NAME SYSTEMATIC_NAME CATEGORY MAIN_CLASS SUB_CLASS CLASS_LEVEL4 EXACT_MASS FORMULA INCHI_KEY INCHI SMILES SYNONYMS PUBCHEM_CID CHEBI_ID SWISSLIPIDS_ID HMDB_ID LIPIDBANK_ID"
+    n_attrs = split(attrs_str, attrs, " ")
+}
+
+{
+    for (i=1; i<=NF; i++) {
+        split($i, lines, "\n")
+        for (j=1; j<=n_attrs; j++) {
+            if (lines[1] == "> <" attrs[j] ">") {
+                vals[attrs[j]] = lines[2]
+            }
+        }
+    }
+    for (j=1; j<=n_attrs; j++) {
+        if (attrs[j] != "LM_ID" && vals[attrs[j]])
+            print vals["LM_ID"], attrs[j], vals[attrs[j]]
+    }
+
+    delete vals
+}

--- a/config/dataset.yaml
+++ b/config/dataset.yaml
@@ -410,6 +410,7 @@ lipidmaps:
   prefix: 'http://identifiers.org/lipidmaps/'
   examples:
     - ["LMST01060010","LMFA01020229","LMFA03020019","LMGP01010915","LMSP03010080","LMFA07070005","LMFA06000216","LMGP01030144","LMFA01170119","LMGP02011194"]
+  method: awk -F "\t" '$2=="NAME"{print $1 "\t" $3}' $TOGOID_ROOT/input/lipidmaps/lipidmaps.tsv
 lncbook_gene:
   label: LncBook gene
   catalog: FIXME

--- a/config/lipidmaps-chebi/config.yaml
+++ b/config/lipidmaps-chebi/config.yaml
@@ -4,4 +4,4 @@ link:
   file: sample.tsv
 update:
   frequency: Weekly
-  method: sparql_csv2tsv.sh query.rq https://lipidmaps.org/sparql
+  method: awk -F "\t" '$2=="CHEBI_ID"{print $1 "\t" $3}' $TOGOID_ROOT/input/lipidmaps/lipidmaps.tsv

--- a/config/lipidmaps-inchi_key/config.yaml
+++ b/config/lipidmaps-inchi_key/config.yaml
@@ -4,4 +4,4 @@ link:
   file: sample.tsv
 update:
   frequency: Weekly
-  method: sparql_csv2tsv.sh query.rq https://lipidmaps.org/sparql
+  method: awk -F "\t" '$2=="INCHI_KEY"{print $1 "\t" $3}' $TOGOID_ROOT/input/lipidmaps/lipidmaps.tsv

--- a/config/lipidmaps-swisslipids/config.yaml
+++ b/config/lipidmaps-swisslipids/config.yaml
@@ -4,4 +4,4 @@ link:
   file: sample.tsv
 update:
   frequency: Weekly
-  method: sparql_csv2tsv.sh query.rq https://lipidmaps.org/sparql
+  method: awk -F "\t" '$2=="SWISSLIPIDS_ID"{print $1 "\t" $3}' $TOGOID_ROOT/input/lipidmaps/lipidmaps.tsv


### PR DESCRIPTION
LIPID MAPS のペアの取得方法を変更。
従来は SPARQL で行っていたが、エンドポイントがしばらく前から停止している。https://lipidmaps.org/sparql
SDF ファイルが提供されているので、これをパースして作成するように変更した。 https://www.lipidmaps.org/databases/lmsd/download